### PR TITLE
Add build-essential package, GNU readline library and gdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install vim make clang gcc valgrind git -y
+RUN apt-get update && apt-get install build-essential libreadline-dev vim clang valgrind git gdb -y
 
 WORKDIR /valgrind
 


### PR DESCRIPTION
Added to the install: build-essential which installs gcc, g++  and make (plus dkpgdev). This is consider the basic package for debian-child distros to build a debian package. Plus, added GNU readline which is used by some projects and gdb that's the best debugger ever created.